### PR TITLE
brewinstall.sh (trigger script) fix?

### DIFF
--- a/install/brewInstall.sh
+++ b/install/brewInstall.sh
@@ -1,4 +1,6 @@
-chmod a+x /$PWD/brewIn.sh
+#!/bin/sh
+
+chmod a+x /$PWD/brewInstall.sh
 chmod a+x /$PWD/brew_install.command
-sudo zsh
+#sudo zsh  (dont think you need elevated permissons)
 /$PWD/brew_install.command -a 2>&1 | tee -a /$PWD/logs/"brewInstall$(date +%F)@$(date +%H:%M:%S).txt"

--- a/install/brewInstall.sh
+++ b/install/brewInstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-chmod a+x /$PWD/brewIn.sh
+chmod a+x /$PWD/brewInstall.sh
 chmod a+x /$PWD/brew_install.command
 sudo zsh  
 /$PWD/brew_install.command -a 2>&1 | tee -a /$PWD/logs/"brewInstall$(date +%F)@$(date +%H:%M:%S).txt"

--- a/install/brewInstall.sh
+++ b/install/brewInstall.sh
@@ -2,5 +2,5 @@
 
 chmod a+x /$PWD/brewInstall.sh
 chmod a+x /$PWD/brew_install.command
-sudo zsh  
+#sudo zsh  
 /$PWD/brew_install.command -a 2>&1 | tee -a /$PWD/logs/"brewInstall$(date +%F)@$(date +%H:%M:%S).txt"

--- a/install/brewInstall.sh
+++ b/install/brewInstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-chmod a+x /$PWD/brewInstall.sh
+chmod a+x /$PWD/brewIn.sh
 chmod a+x /$PWD/brew_install.command
-#sudo zsh  (dont think you need elevated permissons)
+sudo zsh  
 /$PWD/brew_install.command -a 2>&1 | tee -a /$PWD/logs/"brewInstall$(date +%F)@$(date +%H:%M:%S).txt"


### PR DESCRIPTION
Minor fixes I noted after helping a student with installs.

1) added shebang for consistency and portability 
2) fix typo on line 3 (brewIn.sh ...brewInstall.sh)
3) $ sudo zsh doesn't *appear* to be a good idea to use to elevate permissions when running the *entire* brew script (as all installed packages would receive root access and elevated permissions)